### PR TITLE
Force optimizer to update lr

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ python generate_data.py
 CUDA_VISIBLE_DEVICES=$(nvidia-empty) python train.py
 ```
 
+### Fine-tune
+```
+CUDA_VISIBLE_DEVICES=$(nvidia-empty) python train.py --finetune --resume <checkpoint_name>
+```
+
 ## Results
 
 Here are some results from the test set after the training of 200,000 iterations.

--- a/train.py
+++ b/train.py
@@ -92,6 +92,7 @@ if args.finetune:
 else:
     lr = args.lr
 
+start_iter = 0
 optimizer = torch.optim.Adam(
     filter(lambda p: p.requires_grad, model.parameters()), lr=lr)
 criterion = InpaintingLoss(VGG16FeatureExtractor()).to(device)
@@ -99,8 +100,9 @@ criterion = InpaintingLoss(VGG16FeatureExtractor()).to(device)
 if args.resume:
     start_iter = load_ckpt(
         args.resume, [('model', model)], [('optimizer', optimizer)])
-else:
-    start_iter = 0
+    for param_group in optimizer.param_groups:
+        param_group['lr'] = lr
+    print('Starting from iter ', start_iter)
 
 for i in tqdm(range(start_iter, args.max_iter)):
     model.train()


### PR DESCRIPTION
In resume mode, which can also be used for fine-tuning, the learning rate for the optimizer is not updated as suggested in #11, so I have fixed it.